### PR TITLE
Removed IGNORE_MOD_TAP_INTERRUPT, is now standard setting

### DIFF
--- a/keymaps/aptmak/config.h
+++ b/keymaps/aptmak/config.h
@@ -2,9 +2,6 @@
 
 #define TAPPING_TERM 170
 
-// Prevent normal rollover on alphas from accidentally triggering mods.
-#define IGNORE_MOD_TAP_INTERRUPT
-
 // Enable rapid switch from tap to hold, disables double tap hold auto-repeat.
 #define TAPPING_FORCE_HOLD
 

--- a/keymaps/colemak/config.h
+++ b/keymaps/colemak/config.h
@@ -2,9 +2,6 @@
 
 #define TAPPING_TERM 170
 
-// Prevent normal rollover on alphas from accidentally triggering mods.
-#define IGNORE_MOD_TAP_INTERRUPT
-
 // Enable rapid switch from tap to hold, disables double tap hold auto-repeat.
 #define TAPPING_FORCE_HOLD
 

--- a/keymaps/default/config.h
+++ b/keymaps/default/config.h
@@ -2,9 +2,6 @@
 
 #define TAPPING_TERM 170
 
-// Prevent normal rollover on alphas from accidentally triggering mods.
-#define IGNORE_MOD_TAP_INTERRUPT
-
 // Enable rapid switch from tap to hold, disables double tap hold auto-repeat.
 #define TAPPING_FORCE_HOLD
 

--- a/keymaps/meetup/config.h
+++ b/keymaps/meetup/config.h
@@ -2,9 +2,6 @@
 
 #define TAPPING_TERM 170
 
-// Prevent normal rollover on alphas from accidentally triggering mods.
-#define IGNORE_MOD_TAP_INTERRUPT
-
 // Enable rapid switch from tap to hold, disables double tap hold auto-repeat.
 #define TAPPING_FORCE_HOLD
 


### PR DESCRIPTION
QMK exits with an error when IGNORE_MOD_TAP_INTERRUPT is set in config.h

According to the error message it became a standard setting. I removed the lines from the config files for all layouts